### PR TITLE
Fix links in Markdown

### DIFF
--- a/src/build-instructions.md
+++ b/src/build-instructions.md
@@ -51,7 +51,7 @@ Linux 4.9 or higher is required.
 
 * Fedora and CentOS:
 
-  [RPMFusion](https///rpmfusion.org/RPM%20Fusion) is required for FFmpeg.
+  [RPMFusion](https://rpmfusion.org/RPM%20Fusion) is required for FFmpeg.
 
   ```
   $ sudo dnf install make cmake clang bison flex python2 glibc-devel.i686 fuse-devel systemd-devel kernel-devel elfutils-libelf-devel cairo-devel freetype-devel.{x86_64,i686} libjpeg-turbo-devel.{x86_64,i686} libtiff-devel.{x86_64,i686} fontconfig-devel.{x86_64,i686} libglvnd-devel.{x86_64,i686} mesa-libGL-devel.{x86_64,i686} mesa-libEGL-devel.{x86_64,i686} libxml2-devel libbsd-devel git libXcursor-devel giflib-devel ffmpeg-devel pulseaudio-libs-devel

--- a/src/contributing/debugging.md
+++ b/src/contributing/debugging.md
@@ -1,7 +1,7 @@
 # Debugging
 
 We provide a [build of
-LLDB](https///osdn.net/projects/darling/storage/apps/lldb.tar.bz2) that is known
+LLDB](https://osdn.net/projects/darling/storage/apps/lldb.tar.bz2) that is known
 to work under Darling. It is built from vanilla sources, i.e. without any
 modifications.
 
@@ -49,7 +49,7 @@ Please note that environment variables may be missing by default, if used like t
 Debugging support in Darling makes use of what we call "cooperative debugging".
 It means the code in the debuggee is aware it's being debugged and actively
 assists the process. In Darling, this role is taken on mainly by
-[sigexc.c](https///github.com/darlinghq/darling/blob/master/src/kernel/emulation/linux/signal/sigexc.c)
+[sigexc.c](https://github.com/darlinghq/darling/blob/master/src/kernel/emulation/linux/signal/sigexc.c)
 in `libsystem_kernel.dylib`, so no application modifications are necessary.
 
 MacOS debuggers use a combination of BSD-like and Mach APIs to control and
@@ -94,7 +94,7 @@ catch buffer overruns), or with `MALLOC_PROTECT_BEFORE`, before it (to catch
 buffer underruns). You're likely want to try it both ways, with and without
 `MALLOC_PROTECT_BEFORE`. Another useful option is `MALLOC_FILL_SPACE` (similar
 to `MallocPreScribble` from above). See
-[libgmalloc(3)](https///www.manpagez.com/man/3/libgmalloc/) for more details.
+[libgmalloc(3)](https://www.manpagez.com/man/3/libgmalloc/) for more details.
 
 ### Objective-C and Cocoa
 

--- a/src/contributing/generating-stubs.md
+++ b/src/contributing/generating-stubs.md
@@ -73,7 +73,7 @@ Run a build and make sure your new code compiles. After that completes, you are
 ready to submit a pull request.
 
 See [Contributing](README.md) for how to submit a pull request. [This
-commit](https///github.com/darlinghq/darling/commit/92233d4e5ca613658345910d1acf4b3b7620a4f6)
+commit](https://github.com/darlinghq/darling/commit/92233d4e5ca613658345910d1acf4b3b7620a4f6)
 is an example of a stub for a framework that was added to Darling using the
 process described in this article. Most notable is what it does to
 `src/CMakeLists.txt`.

--- a/src/contributing/high-priority-stuff.md
+++ b/src/contributing/high-priority-stuff.md
@@ -6,12 +6,12 @@ areas where work is most needed.
 ## Work to be done
 
 
-* Reimplement [CoreCrypto](https///github.com/darlinghq/darling-corecrypto).
+* Reimplement [CoreCrypto](https://github.com/darlinghq/darling-corecrypto).
 
   CoreCrypto's source code is publicly available, but its license prevents us
   from using it for Darling. Luckily, it's not that difficult! Some work has
   already been done. Having CoreCrypto will also enable us to build a recent
-  version of [CommonCrypto](https///github.com/darlinghq/darling-commoncrypto).
+  version of [CommonCrypto](https://github.com/darlinghq/darling-commoncrypto).
 
 * AppKit.framework
 

--- a/src/darling-shell.md
+++ b/src/darling-shell.md
@@ -47,9 +47,9 @@ Linux
 Should you encounter an application that bails out because you are not root
 (typically because it needs write access outside your home directory), you can
 use the fake `sudo` command. It is fake, because it only makes
-[`getuid()`](https///developer.apple.com/library/mac/documentation/Darwin/Reference/ManPages/man2/getuid.2.html)
+[`getuid()`](https://developer.apple.com/library/mac/documentation/Darwin/Reference/ManPages/man2/getuid.2.html)
 and
-[`geteuid()`](https///developer.apple.com/library/mac/documentation/Darwin/Reference/ManPages/man2/geteuid.2.html)
+[`geteuid()`](https://developer.apple.com/library/mac/documentation/Darwin/Reference/ManPages/man2/geteuid.2.html)
 system calls return 0, but grants you no extra privileges.
 
 ## Examples

--- a/src/installing-software.md
+++ b/src/installing-software.md
@@ -4,7 +4,7 @@ There are multiple ways to install software on macOS, and our aim is to make all
 
 ## You might not even need to install it
 
-[Unlike Wine](https///wiki.winehq.org/FAQ#I_have_lots_of_applications_already_installed_in_Windows._How_do_I_run_them_in_Wine.3F), Darling can run software that's installed on an **existing macOS installation** on the same computer. This is possible thanks to the way application bundles (`.app`-s) work on macOS and Darling.
+[Unlike Wine](https://wiki.winehq.org/FAQ#I_have_lots_of_applications_already_installed_in_Windows._How_do_I_run_them_in_Wine.3F), Darling can run software that's installed on an **existing macOS installation** on the same computer. This is possible thanks to the way application bundles (`.app`-s) work on macOS and Darling.
 
 To use an app that's already installed, you just need to locate the existing installation (e.g. `/Volumes/SystemRoot/run/media/username/Macintosh HD/Applications/SomeApp.app`) and run the app from there.
 
@@ -42,7 +42,7 @@ Unlike macOS, Darling also has the `uninstaller` command, which lets you easily 
 
 ## Package managers
 
-There are many third-party package managers for macOS, the most popular one being [Homebrew](https///brew.sh/). Ultimately, we want to make it possible to use all the existing package managers with Darling, however, some may not work well right now.
+There are many third-party package managers for macOS, the most popular one being [Homebrew](https://brew.sh/). Ultimately, we want to make it possible to use all the existing package managers with Darling, however, some may not work well right now.
 
 ## Command-line developer tools
 

--- a/src/internals/basics/loader.md
+++ b/src/internals/basics/loader.md
@@ -2,13 +2,13 @@
 
 Multiple loaders are involved in loading macOS applications on Linux. This is
 due to the fact that macOS applications use
-[Mach-O](https///en.wikipedia.org/wiki/Mach-O) as the file format of
+[Mach-O](https://en.wikipedia.org/wiki/Mach-O) as the file format of
 applications, dynamic libraries and so on, whereas Linux uses the
-[ELF](https///en.wikipedia.org/wiki/Executable_and_Linkable_Format) format.
+[ELF](https://en.wikipedia.org/wiki/Executable_and_Linkable_Format) format.
 
 ## mldr
 
-[mldr](https///github.com/darlinghq/darling/blob/master/src/startup/mldr.c) is
+[mldr](https://github.com/darlinghq/darling/blob/master/src/startup/mldr.c) is
 the first loader. It's an ordinary Linux executable written in C. Its main
 purpose is to map the Mach-O executable to be started into the memory, find out
 what dynamic linker is required to fully load it (''/usr/lib/dyld'' is used on

--- a/src/internals/basics/system-call-emulation.md
+++ b/src/internals/basics/system-call-emulation.md
@@ -51,7 +51,7 @@ kernels is out of question as well.
 
 * Inability to run software making direct system calls. This includes Go
   applications and some UPX packed executables. Note that [Apple provides no
-  support](https///developer.apple.com/library/content/qa/qa1118/_index.html)
+  support](https://developer.apple.com/library/content/qa/qa1118/_index.html)
   for making direct system calls (which is effectively very similar to
   distributing statically linked executables described in the article) and
   frequently changes the system call table, hence such software is bound to

--- a/src/internals/calling-host-system-apis.md
+++ b/src/internals/calling-host-system-apis.md
@@ -38,7 +38,7 @@ are also passed to all initializers marked with `__attribute__((constructor))`.
 
 The `apple` parameter is ideal for passing additional information without
 interfering with the environment undesirably. `mldr`
-[declares](https///github.com/darlinghq/darling/blob/master/src/startup/elfcalls.h)
+[declares](https://github.com/darlinghq/darling/blob/master/src/startup/elfcalls.h)
 `struct elf_calls` with a set of function pointers, instantiates it and fills it
 out. An address of this structure is then added as a string formatted as
 `elf_calls=%p` into `apple`.

--- a/src/internals/macos-specifics/commpage.md
+++ b/src/internals/macos-specifics/commpage.md
@@ -14,14 +14,14 @@ case of Darling, this functionality is supplemented by `mldr`.
   of certain primitives (e.g. OSAtomicFifoEnqueue). (Not available under
   Darling.)
 
-It is somewhat related to [vDSO](https///en.wikipedia.org/wiki/VDSO) on Linux,
+It is somewhat related to [vDSO](https://en.wikipedia.org/wiki/VDSO) on Linux,
 except that vDSO behaves like a real library, while commpage is just a chunk of
 data.
 
 The commpage is not documented anywhere, meaning it's not an API intended to be
 used by 3rd party software. It is however used in source code provided on
 [opensource.apple.com](http://opensource.apple.com). Darling
-[provides](https///github.com/darlinghq/darling/blob/master/src/startup/commpage.c)
+[provides](https://github.com/darlinghq/darling/blob/master/src/startup/commpage.c)
 a commpage for compatibility reasons.
 
 ## Location

--- a/src/internals/macos-specifics/mach-ports.md
+++ b/src/internals/macos-specifics/mach-ports.md
@@ -211,7 +211,7 @@ to contain:
 The only way for a task to get a port right for a port is to either create that
 port, or have some other task (or the kernel) send it the right. In this way,
 Mach ports are *capabilities* (as in [capability-based
-security](https///en.wikipedia.org/wiki/Capability-based_security)).
+security](https://en.wikipedia.org/wiki/Capability-based_security)).
 
 Among other things, that means that for Mach programs (including the kernel
 itself) which allow other tasks to ask it to perform operations by sending
@@ -235,10 +235,10 @@ inherited:
   held by the kernel. This port allows to manipulate the task it refers to,
   including reading and writing its virtual memory, creating and otherwise
   manipulating its threads, and terminating (killing) the task (see
-  [task.defs](https///github.com/darlinghq/darling/blob/master/platform-include/mach/task.defs),
-  [mach_vm.defs](https///github.com/darlinghq/darling/blob/master/platform-include/mach/mach_vm.defs)
+  [task.defs](https://github.com/darlinghq/darling/blob/master/platform-include/mach/task.defs),
+  [mach_vm.defs](https://github.com/darlinghq/darling/blob/master/platform-include/mach/mach_vm.defs)
   and
-  [vm_map.defs](https///github.com/darlinghq/darling/blob/master/platform-include/mach/vm_map.defs)).
+  [vm_map.defs](https://github.com/darlinghq/darling/blob/master/platform-include/mach/vm_map.defs)).
   Call `mach_task_self()` to get the name for this port for the caller task.
   This port is only inherited across `exec()`; a new task created with `fork()`
   gets a new task port (as a special case, a task also gets a new task port
@@ -246,18 +246,18 @@ inherited:
   allows creating new tasks returns the task port of the new task to the caller;
   but it's unavailable (always returns `KERN_FAILURE`) on Darwin, so the only
   way to spawn a task and get its port is to perform the ["port swap
-  dance"](https///robert.sesek.com/2014/1/changes_to_xnu_mach_ipc.html) while
+  dance"](https://robert.sesek.com/2014/1/changes_to_xnu_mach_ipc.html) while
   doing a `fork()`.
 
 * **Host port**, a send right to another port whose receive right is held by the
   kernel. The host port allows getting information about the kernel and the host
   machine, such as the OS (kernel) version, number of processors and memory
   usage statistics (see
-  [mach_host.defs](https///github.com/darlinghq/darling/blob/master/platform-include/mach/mach_host.defs)).
+  [mach_host.defs](https://github.com/darlinghq/darling/blob/master/platform-include/mach/mach_host.defs)).
   Get it using `mach_host_self()`. There also exists a "privileged host control
   port" (`host_priv_t`) that allows privileged tasks (aka processes running as
   root) to *control* the host (see
-  [host_priv.defs](https///github.com/darlinghq/darling/blob/master/platform-include/mach/host_priv.defs)).
+  [host_priv.defs](https://github.com/darlinghq/darling/blob/master/platform-include/mach/host_priv.defs)).
   The official way to get it is by calling `host_get_host_priv_port()` passing
   the "regular" host port; in reality it returns either the same port name (if
   the task is privileged) or `MACH_PORT_NULL` (if it's not).
@@ -310,7 +310,7 @@ There also are two special sets of ports that tasks inherit:
   Under Darling, the Linux kernel delivers these kinds of events as Unix signals
   to the process that they happen in, then the process converts the received
   signals to Mach exceptions and sends them to the correct exception port (see
-  [sigexc.c](https///github.com/darlinghq/darling/blob/master/src/kernel/emulation/linux/signal/sigexc.c)).
+  [sigexc.c](https://github.com/darlinghq/darling/blob/master/src/kernel/emulation/linux/signal/sigexc.c)).
 
 As a Darwin extension, there are `pid_for_task()`, `task_for_pid()`, and
 `task_name_for_pid()` syscalls that allow converting between Mach task ports and
@@ -661,7 +661,7 @@ doesn't try to hide the possibility of connection errors, and only allows
 passing whitelisted types (to prevent certain kinds of attacks).
 
 Apple's XPC is not open source. On Darling, the low-level XPC implementation
-([libxpc](https///github.com/darlinghq/darling-libxpc)) is based on NextBSD
+([libxpc](https://github.com/darlinghq/darling-libxpc)) is based on NextBSD
 libxpc. The high-level Cocoa APIs are not yet implemented.
 
 ## Useful resources
@@ -669,19 +669,19 @@ libxpc. The high-level Cocoa APIs are not yet implemented.
 Note that Apple's version of Mach as used in XNU/Darwin is subtly different than
 both OSF Mach and GNU Mach.
 
-* [Inter Process Communication - The GNU Mach Reference Manual](https///www.gnu.org/software/hurd/gnumach-doc/Inter-Process-Communication.html)
+* [Inter Process Communication - The GNU Mach Reference Manual](https://www.gnu.org/software/hurd/gnumach-doc/Inter-Process-Communication.html)
 * [Mach Kernel Interface Reference Manual](http://web.mit.edu/darwin/src/modules/xnu/osfmk/man/)
-* [Changes to XNU Mach IPC](https///robert.sesek.com/2014/1/changes_to_xnu_mach_ipc.html)
-* [Debugging Mach Ports](https///robert.sesek.com/2012/1/debugging_mach_ports.html)
+* [Changes to XNU Mach IPC](https://robert.sesek.com/2014/1/changes_to_xnu_mach_ipc.html)
+* [Debugging Mach Ports](https://robert.sesek.com/2012/1/debugging_mach_ports.html)
 * [Some Fun with Mach Ports](http://www.foldr.org/~michaelw/log/computers/macosx/task-info-fun-with-mach)
 * [Reaching the MACH layer](http://blog.wuntee.sexy/reaching-the-mach-layer)
 * [Interprocess communication on iOS with Mach messages](http://ddeville.me/2015/02/interprocess-communication-on-ios-with-mach-messages)
 * [Mach Message and Bootstrap Server on OS X](http://przhu.github.io/using%20mac/2012/08/25/mach-message-and-bootstrap-server-on-os-x/)
-* [Friday Q&A 2013-01-11: Mach Exception Handlers](https///www.mikeash.com/pyblog/friday-qa-2013-01-11-mach-exception-handlers.html)
+* [Friday Q&A 2013-01-11: Mach Exception Handlers](https://www.mikeash.com/pyblog/friday-qa-2013-01-11-mach-exception-handlers.html)
 * [Mach 3 Server Writer's Guide](http://shakthimaan.com/downloads/hurd/server_writer.pdf)
-* [Revisiting Apple IPC: (1) Distributed Objects](https///googleprojectzero.blogspot.com/2015/09/revisiting-apple-ipc-1-distributed_28.html)
-* [About Distributed Objects](https///developer.apple.com/library/archive/documentation/Cocoa/Conceptual/DistrObjects/Concepts/AboutDistributedObjects.html)
+* [Revisiting Apple IPC: (1) Distributed Objects](https://googleprojectzero.blogspot.com/2015/09/revisiting-apple-ipc-1-distributed_28.html)
+* [About Distributed Objects](https://developer.apple.com/library/archive/documentation/Cocoa/Conceptual/DistrObjects/Concepts/AboutDistributedObjects.html)
 * [GNUstep Distributed Objects](http://www.gnustep.it/nicola/Tutorials/DistributedObjects/)
 * [Objective-C GNUstep Base Programming Manual: 7. Distributed Objects](http://www.gnustep.org/resources/documentation/Developer/Base/ProgrammingManual/manual_7.html)
-* [Creating XPC Services](https///developer.apple.com/library/archive/documentation/MacOSX/Conceptual/BPSystemStartup/Chapters/CreatingXPCServices.html)
-* [Auditing and Exploiting Apple IPC](https///thecyberwire.com/events/docs/IanBeer_JSS_Slides.pdf)
+* [Creating XPC Services](https://developer.apple.com/library/archive/documentation/MacOSX/Conceptual/BPSystemStartup/Chapters/CreatingXPCServices.html)
+* [Auditing and Exploiting Apple IPC](https://thecyberwire.com/events/docs/IanBeer_JSS_Slides.pdf)

--- a/src/internals/threading/thread-implementation.md
+++ b/src/internals/threading/thread-implementation.md
@@ -7,7 +7,7 @@ under Darling therefore use the same exact threading library as on macOS.
 
 Apple's libpthread manages threads through a collection of `bsdthread*` system
 calls, which are [implemented by
-Darling](https///github.com/darlinghq/darling/tree/master/src/kernel/emulation/linux/bsdthread).
+Darling](https://github.com/darlinghq/darling/tree/master/src/kernel/emulation/linux/bsdthread).
 This way Apple's libpthread could operate absolutely independently on Linux.
 
 However, there is a huge catch. Darling could set up threads on its own and
@@ -21,7 +21,7 @@ thread-local storage access as well.
 
 In Darling, `bsdthread*` system calls call back into the
 [loader](../basics/loader.md), which
-[uses](https///github.com/darlinghq/darling/blob/master/src/startup/threads.c)
+[uses](https://github.com/darlinghq/darling/blob/master/src/startup/threads.c)
 native libpthread to start a thread. Once native libpthread sets up the thread,
 the control is handed over to Apple's libpthread.
 

--- a/src/internals/threading/thread-local-storage.md
+++ b/src/internals/threading/thread-local-storage.md
@@ -13,7 +13,7 @@ libpthread (otherwise `pthread_self()` would not work) and also in libc itself
 (`errno` is typically a per-thread value to avoid races).
 
 On 32/64-bit x86, old [segment
-registers](https///en.wikipedia.org/wiki/X86_memory_segmentation) from the
+registers](https://en.wikipedia.org/wiki/X86_memory_segmentation) from the
 16-bit times have found new use thanks to TLS.
 
 ## TLS setup
@@ -21,7 +21,7 @@ registers](https///en.wikipedia.org/wiki/X86_memory_segmentation) from the
 1. When a new thread is being set up, a block of memory is allocated by
    libpthread. This block of memory is usually what `pthread_self()` returns.
 2. libpthread asks the kernel to set up a new
-   [GDT](https///en.wikibooks.org/wiki/X86_Assembly/Global_Descriptor_Table)
+   [GDT](https://en.wikibooks.org/wiki/X86_Assembly/Global_Descriptor_Table)
    entry that refers to this memory block.
 3. The entry number is then set into the respective segment register.
 

--- a/src/what-to-try.md
+++ b/src/what-to-try.md
@@ -239,7 +239,7 @@ Darling [~]$ curl http://example.og
 ## Try using sudo
 
 Just like [the real Mac OS X
-may](https///www.macrumors.com/2017/11/28/macos-high-sierra-bug-admin-access/),
+may](https://www.macrumors.com/2017/11/28/macos-high-sierra-bug-admin-access/),
 Darling allows you to get root priveleges without having to enter any password,
 except in our case it's a feature:
 
@@ -323,7 +323,7 @@ Darling [~]$ man defaults
 
 ## Run neofetch
 
-Get the `neofetch.sh` script from [its homepage](https///github.com/dylanaraps/neofetch ) and run it:
+Get the `neofetch.sh` script from [its homepage](https://github.com/dylanaraps/neofetch ) and run it:
 
 ```
 Darling [~]$ bash neofetch.sh


### PR DESCRIPTION
Pretty simple fix, just a quick find-and-replace on all triple-slashes (`///` -> `://`); should fix external links.