### PR TITLE
Add libXrandr-devel to Fedora/CentOS dependency list

### DIFF
--- a/src/build-instructions.md
+++ b/src/build-instructions.md
@@ -54,7 +54,7 @@ Linux 4.9 or higher is required.
   [RPMFusion](https://rpmfusion.org/RPM%20Fusion) is required for FFmpeg.
 
   ```
-  $ sudo dnf install make cmake clang bison flex python2 glibc-devel.i686 fuse-devel systemd-devel kernel-devel elfutils-libelf-devel cairo-devel freetype-devel.{x86_64,i686} libjpeg-turbo-devel.{x86_64,i686} libtiff-devel.{x86_64,i686} fontconfig-devel.{x86_64,i686} libglvnd-devel.{x86_64,i686} mesa-libGL-devel.{x86_64,i686} mesa-libEGL-devel.{x86_64,i686} libxml2-devel libbsd-devel git libXcursor-devel giflib-devel ffmpeg-devel pulseaudio-libs-devel
+  $ sudo dnf install make cmake clang bison flex python2 glibc-devel.i686 fuse-devel systemd-devel kernel-devel elfutils-libelf-devel cairo-devel freetype-devel.{x86_64,i686} libjpeg-turbo-devel.{x86_64,i686} libtiff-devel.{x86_64,i686} fontconfig-devel.{x86_64,i686} libglvnd-devel.{x86_64,i686} mesa-libGL-devel.{x86_64,i686} mesa-libEGL-devel.{x86_64,i686} libxml2-devel libbsd-devel git libXcursor-devel libXrandr-devel giflib-devel ffmpeg-devel pulseaudio-libs-devel
   ```
 
 


### PR DESCRIPTION
This is not installed by default on Fedora 32 Workstation beta at the very least, and CMake fails without it.