### PR TITLE
Add gcc-multilib to Debian 10 dependencies

### DIFF
--- a/src/build-instructions.md
+++ b/src/build-instructions.md
@@ -17,7 +17,7 @@ Linux 4.9 or higher is required.
 * Debian 10:
 
   ```
-  $ sudo apt install cmake clang-6.0 bison flex xz-utils libfuse-dev libudev-dev pkg-config libc6-dev-i386 linux-headers-amd64 libcap2-bin git libcairo2-dev libgl1-mesa-dev libtiff5-dev libfreetype6-dev libxml2-dev libegl1-mesa-dev libfontconfig1-dev libbsd-dev libxrandr-dev libxcursor-dev libgif-dev libpulse-dev libavformat-dev libavcodec-dev libavresample-dev
+  $ sudo apt install cmake clang-6.0 bison flex xz-utils libfuse-dev libudev-dev pkg-config libc6-dev-i386 linux-headers-amd64 libcap2-bin gcc-multilib git libcairo2-dev libgl1-mesa-dev libtiff5-dev libfreetype6-dev libxml2-dev libegl1-mesa-dev libfontconfig1-dev libbsd-dev libxrandr-dev libxcursor-dev libgif-dev libpulse-dev libavformat-dev libavcodec-dev libavresample-dev
   ````
 
 * Debian Testing:


### PR DESCRIPTION
Without this, compilation failed on `libelfloader/native/elfcalls.c` not finding `asm/errno.h`.