### PR TITLE
Various doc fixes

### DIFF
--- a/src/build-instructions.md
+++ b/src/build-instructions.md
@@ -162,11 +162,23 @@ Use the following commands to generate a key and self-sign the kernel module:
 openssl req -new -x509 -newkey rsa:2048 -keyout MOK.priv -outform DER -out MOK.der -nodes -days 36500 -subj "/CN=Darling LKM/"
 # Enroll Key
 sudo mokutil --import MOK.der
-# Sign Module
+```
+
+The signing tool is `scripts/sign-file.c` within the kernel source tree. See `Documentation/admin-guide/module-signing.rst` at https://www.kernel.org for usage.
+This tool is packaged differently for different Linux distributions:
+
+```
+# Fedora - Sign Module
+sudo /lib/modules/$(uname -r)/build/scripts/sign-file sha512 MOK.priv MOK.der /lib/modules/$(uname -r)/extra/darling-mach.ko
+
+# Ubuntu (not Debian) - Sign Module
 sudo kmodsign sha512 MOK.priv MOK.der /lib/modules/$(uname -r)/extra/darling-mach.ko
+
 # Reboot System and Enroll Key
 ```
 
+Debian / Raspbian does not provide this tool in binary form (Debian bug #939393, Sept 2019), nor SuSE. You may need to build it by `make scripts`
+in a kernel source tree.
 
 ### No rule to make target 'modules'
 

--- a/src/build-instructions.md
+++ b/src/build-instructions.md
@@ -71,8 +71,7 @@ If you have already cloned Darling and would like to get the latest changes, do 
 
 ```
 $ git pull
-$ git submodule init
-$ git submodule update
+$ git submodule update --init --recursive
 ```
 
 # Build

--- a/src/build-instructions.md
+++ b/src/build-instructions.md
@@ -54,6 +54,7 @@ Linux 4.19 or higher is required.
   $ sudo dnf install make cmake clang bison dbus-devel flex python2 glibc-devel.i686 fuse-devel systemd-devel kernel-devel elfutils-libelf-devel cairo-devel freetype-devel.{x86_64,i686} libjpeg-turbo-devel.{x86_64,i686} libtiff-devel.{x86_64,i686} fontconfig-devel.{x86_64,i686} libglvnd-devel.{x86_64,i686} mesa-libGL-devel.{x86_64,i686} mesa-libEGL-devel.{x86_64,i686} libxml2-devel libbsd-devel git libXcursor-devel libXrandr-devel giflib-devel ffmpeg-devel pulseaudio-libs-devel libxkbfile-devel
   ```
 
+  See also the `rpm/` sub-directory for docker-compose instructions.
 
 # Fetch the Sources
 

--- a/src/build-instructions.md
+++ b/src/build-instructions.md
@@ -144,6 +144,7 @@ Cannot open mnt namespace file: No such file or directory
 ```
 
 To work around this try this command: `setsebool -P mmap_low_allowed 1`.
+( `-P` means persistent - Don't use this option if you prefer to auto-revert this change after reboot.)
 
 ### Secure Boot
 

--- a/src/what-to-try.md
+++ b/src/what-to-try.md
@@ -221,6 +221,9 @@ System/
     com.apple.xpc.system (XPC Singleton Domain)/
 ```
 
+And, `launchctl shutdown` for completely shutting down darling, including lingering background processes.
+This might be useful if you want to unload the kernel modules, for example.
+
 Read `man launchctl` for more information of other commands `launchctl` has.
 
 ## Fetch a webpage


### PR DESCRIPTION
The most important part is the authentic way of signing kernel modules. The existing one is Ubuntu(not even Debian)-specific.

I myself use the Fedora instructions, and checked it also on Raspbian .