### PR TITLE
Fix build instructions

### DIFF
--- a/src/build-instructions.md
+++ b/src/build-instructions.md
@@ -4,9 +4,9 @@ You must be running a 64-bit x86 Linux distribution. Darling cannot be used on a
 
 # Dependencies
 
-It is recommended that you use at least Clang 3.8. You can force a specific version of Clang (if it is installed on your system) by editing `Toolchain.cmake`.
+It is recommended that you use at least Clang 6. You can force a specific version of Clang (if it is installed on your system) by editing `Toolchain.cmake`.
 
-Linux 4.19 or higher is required.
+Linux 5.0 or higher is required.
 
 
 **Debian 10**
@@ -159,8 +159,8 @@ If you wish to properly move your Darling installation, the only supported optio
 If your distribution is Backbox and you run into build issues try the following commands:
 
 ```
-sudo update-alternatives --install /usr/bin/clang clang /usr/bin/clang-4.0 400
-sudo update-alternatives --install /usr/bin/clang++ clang++ /usr/bin/clang++-4.0 400
+sudo update-alternatives --install /usr/bin/clang clang /usr/bin/clang-6.0 600
+sudo update-alternatives --install /usr/bin/clang++ clang++ /usr/bin/clang++-6.0 600
 ```
 
 ### SELinux

--- a/src/darling-shell.md
+++ b/src/darling-shell.md
@@ -21,7 +21,7 @@ The filesystem layout inside the container is similar to that of macOS,
 including the top-level `/Applications`, `/Users` and `/System` directories. The
 original Linux filesystem is visible as a separate partition that's mounted on
 `/Volumes/SystemRoot`. When running macOS programs under Darling, you'll likely
-want them to access files in you home folder; to make this convenient, there's a
+want them to access files in your home folder; to make this convenient, there's a
 `LinuxHome` symlink in your Darling home folder that points to your Linux home
 folder, as seen from inside the container; additionally, standard directories
 such as `Downloads` in your Darling home folder are symlinked to the

--- a/src/installing-software.md
+++ b/src/installing-software.md
@@ -32,7 +32,7 @@ Many apps are only available via Apple's Mac App Store. To install such an appli
 
 Many apps use `.pkg`, the native package format of macOS, as their distribution format. It's not enough to simply copy the contents of a package somewhere, they are really meant to be *installed* and can run arbitrary scripts during installation.
 
-Under macOS, you would use the graphical Installer.app or the command-line `installer` utility to install this kind of packages. You can do the latter under Darling as well:
+Under macOS, you would use the graphical Installer.app or the command-line `installer` utility to install this kind of package. You can do the latter under Darling as well:
 
 ```
 Darling [~]$ installer -pkg mc-4.8.7-0.pkg -target /


### PR DESCRIPTION
Updates minimum recommended versions of clang 3.8 -> 6 and Linux kernel 4.19 -> 5.0.  This stems from discussions in darlinghq/darling#774 darlinghq/darling#823 darlinghq/darling#853

Later versions have been mentioned as new minimum versions but I notice we were still recommending that Debian (stable) users explicitly install clang 6.0.  I did a little research and found that Debian (stable) "buster" defaults to clang 7.0[*].  (That's also the most recent version of clang available in the repositories for Debian "stable".)  Would that be preferable to clang 6.0?

Reference:
[*]  https://packages.debian.org/search?keywords=clang&searchon=names&suite=stable&section=all