### PR TITLE
update clang-6.0 to clang-11

### DIFF
--- a/src/build-instructions.md
+++ b/src/build-instructions.md
@@ -12,7 +12,7 @@ Linux 5.0 or higher is required.
 **Debian 10**
 
   ```
-  $ sudo apt install cmake clang-6.0 bison flex xz-utils libfuse-dev libudev-dev pkg-config \
+  $ sudo apt install cmake clang-11 bison flex xz-utils libfuse-dev libudev-dev pkg-config \
   libc6-dev-i386 linux-headers-amd64 libcap2-bin git python2 libglu1-mesa-dev libcairo2-dev \
   libgl1-mesa-dev libtiff5-dev libfreetype6-dev libxml2-dev libegl1-mesa-dev libfontconfig1-dev \
   libbsd-dev libxrandr-dev libxcursor-dev libgif-dev libpulse-dev libavformat-dev libavcodec-dev \


### PR DESCRIPTION
Darling no longer builds with `clang-6.0` (https://github.com/darlinghq/darling/issues/964, https://github.com/darlinghq/darling/issues/939, and `clang-11` is available from buster-backports, so I don't think we should suggest using it.