### PR TITLE
Lower minimum clang version

### DIFF
--- a/src/build-instructions.md
+++ b/src/build-instructions.md
@@ -4,7 +4,7 @@ You must be running a 64-bit x86 Linux distribution. Darling cannot be used on a
 
 # Dependencies
 
-Clang is required to compile Darling; at least Clang 9 is required. You can force a specific version of Clang (if it is installed on your system) by editing `Toolchain.cmake`.
+Clang is required to compile Darling; at least Clang 6 is required. You can force a specific version of Clang (if it is installed on your system) by editing `Toolchain.cmake`.
 
 Linux 5.0 or higher is required.
 


### PR DESCRIPTION
https://github.com/darlinghq/darling/commit/4fbf800df4dfa6e6159b2f97c8a053c9489e9dce fixes builds for clang 6, 7 and 8