### PR TITLE
Provide anchor link for lkm

### DIFF
--- a/src/build-instructions.md
+++ b/src/build-instructions.md
@@ -152,7 +152,7 @@ $ make
 $ sudo make install
 ```
 
-
+### Kernel Module
 Darling also requires a kernel module named `darling-mach`:
 
 ```


### PR DESCRIPTION
A missing `lkm` seems to be a common occurrence.  Provide anchor link for helping others.