### PR TITLE
Fix broken link by bringing back old WSL page, link to usual instructions

### DIFF
--- a/src/SUMMARY.md
+++ b/src/SUMMARY.md
@@ -3,6 +3,7 @@
 - [Introduction](README.md)
 - [Using Darling](using-darling.md)
   - [Build instructions](build-instructions.md)
+  - [Building for the WSL](wsl-build.md)
   - [Uninstall](uninstall.md)
   - [Darling shell](darling-shell.md)
   - [Darling prefix](darling-prefix.md)

--- a/src/wsl-build.md
+++ b/src/wsl-build.md
@@ -1,0 +1,7 @@
+# Building for the WSL
+
+The Windows Subsystem for Linux (or WSL for short) allows you to run Linux programs on a Windows system.
+
+Darling should work with no problems on WSL2, as this is essentially a standard virtual machine with a full Linux kernel. WSL1 is more complicated and is not currently working.
+
+As Darling no longer uses a Linux Kernel Module, no special instructions are needed for either WSL1 or WSL2. Use the standard [Linux build instructions](build-instructions.md).


### PR DESCRIPTION
Brings back the old WSL page to fix the broken link, but just links to the standard build instructions and explains why we no longer need any special setup.