### PR TITLE
Add extra information and correct links for Classic Finder.

### DIFF
--- a/src/known-partial-software.md
+++ b/src/known-partial-software.md
@@ -1,8 +1,10 @@
 # Known partially working software
 The following software has been tested and is known to work partially with Darling:
 
-- Classic Finder (https://web.archive.org/web/20220407135022/https://www.classicmacfinder.com/).
+- Classic Finder (https://classicmacfinder.com/).
+  - Source code: https://bitbucket.org/bszyman/classic-finder-app/src/develop/
   - Works, but has the following bugs:
+  - Menubar not visible anywhere.
   - Windows cannot be closed after they lose focus - the window decorations disappear.
   - Sometimes does not respond when trying to browse to system folders.
   - Runs very slowly.


### PR DESCRIPTION
Add extra information and correct links for Classic Finder.

- Add correct website link, no need to use archive.org.
- Add source code link.
- Add note about missing menubar.