### PR TITLE
Include new test results and reorganise Homebrew results

### DIFF
--- a/src/known-working-software.md
+++ b/src/known-working-software.md
@@ -1,8 +1,10 @@
 # Known working software
 The following software has been tested to work with Darling:
 
+- Homebrew.
+  - Terminal GNU Emacs 28.1, installed via brew
+  - CMake 3.23.2, installed via brew
+  - GNUPlot, installed via brew, when outputting to PNG files.
+  - Python 3.9, installed via brew.
 - The Xcode commandline tools.
-- Python 3.10 (From https://www.python.org), including pip.
 - GNUPlot (http://www.gnuplot.info/), when outputting to PNG files.
-- Terminal GNU Emacs 28.1, installed via brew
-- CMake 3.23.2, installed via brew


### PR DESCRIPTION
Include new test results and reorganise Homebrew results.

Also remove Python.org Python 3.10, as it currently is not working.