### PR TITLE
Debian: Add missing package 'llvm-dev' needed to build debug symbols

### DIFF
--- a/src/build-instructions.md
+++ b/src/build-instructions.md
@@ -18,7 +18,7 @@ sudo apt install cmake clang-6.0 bison flex xz-utils libfuse-dev libudev-dev pkg
 libc6-dev-i386 libcap2-bin git git-lfs python2 libglu1-mesa-dev libcairo2-dev \
 libgl1-mesa-dev libtiff5-dev libfreetype6-dev libxml2-dev libegl1-mesa-dev libfontconfig1-dev \
 libbsd-dev libxrandr-dev libxcursor-dev libgif-dev libpulse-dev libavformat-dev libavcodec-dev \
-libswresample-dev libdbus-1-dev libxkbfile-dev libssl-dev
+libswresample-dev libdbus-1-dev libxkbfile-dev libssl-dev llvm-dev
 ```
 
 **Debian Testing**

--- a/src/build-instructions.md
+++ b/src/build-instructions.md
@@ -28,7 +28,7 @@ sudo apt install cmake clang-9 bison flex xz-utils libfuse-dev libudev-dev pkg-c
 libc6-dev-i386 libcap2-bin git git-lfs python2 libglu1-mesa-dev libcairo2-dev \
 libgl1-mesa-dev libtiff5-dev libfreetype6-dev libxml2-dev libegl1-mesa-dev libfontconfig1-dev \
 libbsd-dev libxrandr-dev libxcursor-dev libgif-dev libpulse-dev libavformat-dev libavcodec-dev \
-libswresample-dev libdbus-1-dev libxkbfile-dev libssl-dev
+libswresample-dev libdbus-1-dev libxkbfile-dev libssl-dev llvm-dev
 ```
 
 **Ubuntu 18.04/20.04:**


### PR DESCRIPTION
Add missing dependency for Debian, needed to build debug symbols.