### PR TITLE
Updated Arch & Manjaro to install glu package

### DIFF
--- a/src/build-instructions.md
+++ b/src/build-instructions.md
@@ -58,7 +58,7 @@ Install dependencies:
 ```bash
 yay -S python2
 sudo pacman -S --needed make cmake clang flex bison icu fuse gcc-multilib \
-lib32-gcc-libs pkg-config fontconfig cairo libtiff mesa llvm libbsd libxkbfile \
+lib32-gcc-libs pkg-config fontconfig cairo libtiff mesa glu llvm libbsd libxkbfile \
 libxcursor libxext libxkbcommon libxrandr ffmpeg git git-lfs
 ```
 


### PR DESCRIPTION
* Added `glu` to **Arch Linux & Manjaro** section's `pacman -S …` dependencies command.

For Arch (my machine) and AFAICT Manjaro, `libGLU.so` is no longer included as part of the *mesa* package or one of it's dependencies— it's now required to install the *glu* package (https://archlinux.org/packages/extra/x86_64/glu/).