### PR TITLE
Add build instructions for Debian 12

### DIFF
--- a/src/build-instructions.md
+++ b/src/build-instructions.md
@@ -10,11 +10,19 @@ A minimum of 4 GB of RAM is also required for building. Using swap space may hel
 
 Linux 5.0 or higher is required.
 
-
 **Debian 10/11**
 
 ```bash
 sudo apt install cmake clang-6.0 bison flex xz-utils libfuse-dev libudev-dev pkg-config \
+libc6-dev-i386 libcap2-bin git git-lfs libglu1-mesa-dev libcairo2-dev \
+libgl1-mesa-dev libtiff5-dev libfreetype6-dev libxml2-dev libegl1-mesa-dev libfontconfig1-dev \
+libbsd-dev libxrandr-dev libxcursor-dev libgif-dev libpulse-dev libavformat-dev libavcodec-dev \
+libswresample-dev libdbus-1-dev libxkbfile-dev libssl-dev llvm-dev
+```
+
+**Debian 12**
+```bash
+sudo apt install cmake clang bison flex xz-utils libfuse-dev libudev-dev pkg-config \
 libc6-dev-i386 libcap2-bin git git-lfs libglu1-mesa-dev libcairo2-dev \
 libgl1-mesa-dev libtiff5-dev libfreetype6-dev libxml2-dev libegl1-mesa-dev libfontconfig1-dev \
 libbsd-dev libxrandr-dev libxcursor-dev libgif-dev libpulse-dev libavformat-dev libavcodec-dev \


### PR DESCRIPTION
Just add some slightly modified build instructions for Debian 12, seeing as clang 6 isn't available any more.