### PR TITLE
Update known working software to include Python 3.11 from Python.org,…

### DIFF
--- a/src/known-working-software.md
+++ b/src/known-working-software.md
@@ -5,6 +5,7 @@ The following software has been tested to work with Darling:
   - Terminal GNU Emacs 28.1, installed via brew
   - CMake 3.23.2, installed via brew
   - GNUPlot, installed via brew, when outputting to PNG files.
-  - Python 3.9, installed via brew.
+  - Python 3, installed via brew.
 - The Xcode commandline tools.
 - GNUPlot (http://www.gnuplot.info/), when outputting to PNG files.
+- Python 3.11 from https://www.python.org


### PR DESCRIPTION
… and note that Python 3 in general from Homebrew works