### PR TITLE
Add libtiff-devel.i686 to Fedora/etc dependencies

### DIFF
--- a/src/build-instructions.md
+++ b/src/build-instructions.md
@@ -71,7 +71,7 @@ lib32-gcc-libs pkg-config fontconfig cairo libtiff mesa glu llvm libbsd libxkbfi
 libxcursor libxext libxkbcommon libxrandr ffmpeg git git-lfs
 ```
 
-**Fedora 39, RHEL 9, CentOS Stream 9, and AlmaLinux 9**
+**Fedora 40, RHEL 9, CentOS Stream 9, and AlmaLinux 9**
 
 ```bash
 sudo dnf install make cmake clang bison dbus-devel flex glibc-devel.i686 fuse-devel \

--- a/src/build-instructions.md
+++ b/src/build-instructions.md
@@ -78,7 +78,7 @@ sudo dnf install make cmake clang bison dbus-devel flex glibc-devel.i686 fuse-de
 systemd-devel elfutils-libelf-devel cairo-devel freetype-devel.{x86_64,i686} \
 libjpeg-turbo-devel.{x86_64,i686} fontconfig-devel.{x86_64,i686} libglvnd-devel.{x86_64,i686} \
 mesa-libGL-devel.{x86_64,i686} mesa-libEGL-devel.{x86_64,i686} mesa-libGLU-devel.{x86_64,i686} \
-libtiff-devel{x86_64,i686} libxml2-devel libbsd-devel git git-lfs libXcursor-devel \
+libtiff-devel.{x86_64,i686} libxml2-devel libbsd-devel git git-lfs libXcursor-devel \
 libXrandr-devel giflib-devel pulseaudio-libs-devel libxkbfile-devel \
 openssl-devel llvm libcap-devel libavcodec-free-devel libavformat-free-devel
 ```

--- a/src/build-instructions.md
+++ b/src/build-instructions.md
@@ -71,14 +71,14 @@ lib32-gcc-libs pkg-config fontconfig cairo libtiff mesa glu llvm libbsd libxkbfi
 libxcursor libxext libxkbcommon libxrandr ffmpeg git git-lfs
 ```
 
-**Fedora and CentOS**
+**Fedora 39, RHEL 9, CentOS Stream 9, and AlmaLinux 9**
 
 ```bash
 sudo dnf install make cmake clang bison dbus-devel flex glibc-devel.i686 fuse-devel \
 systemd-devel elfutils-libelf-devel cairo-devel freetype-devel.{x86_64,i686} \
 libjpeg-turbo-devel.{x86_64,i686} fontconfig-devel.{x86_64,i686} libglvnd-devel.{x86_64,i686} \
 mesa-libGL-devel.{x86_64,i686} mesa-libEGL-devel.{x86_64,i686} mesa-libGLU-devel.{x86_64,i686} \
-libtiff-devel libxml2-devel libbsd-devel git git-lfs libXcursor-devel \
+libtiff-devel{x86_64,i686} libxml2-devel libbsd-devel git git-lfs libXcursor-devel \
 libXrandr-devel giflib-devel pulseaudio-libs-devel libxkbfile-devel \
 openssl-devel llvm libcap-devel libavcodec-free-devel libavformat-free-devel
 ```


### PR DESCRIPTION
Fixes missing `tiffconf-32.h`