### PR TITLE
Added paragraph about SSE3 support to build-instructions.md.

### DIFF
--- a/src/build-instructions.md
+++ b/src/build-instructions.md
@@ -295,7 +295,7 @@ Cannot mount overlay: Invalid argument
 
 ### SSE3 Support
 
-When running on older CPUs without SSE3 Support you might run into issues like: 
+When running on older CPUs without SSE3 Support, you might run into issues like: 
 
 ```
 user$ darling shell
@@ -312,9 +312,9 @@ Bootstrapping the container with launchd...
 Illegal instruction (core dumped)
 ```
 
-If your CPU doesn't support SSE3 you might still be able to run darling by installing the opemu-linux kernel module.
+If your CPU doesn't support SSE3, you might still be able to run darling by installing the opemu-linux kernel module.
 
-But first check `/proc/cpuinfo` to find out if your CPU supports SSE3 e.g. by running `cat /proc/cpuinfo | grep SSE3`. Unless it comes back with `SSE3` your CPU doesn't support SSE3.
+But first check `/proc/cpuinfo` to find out if your CPU supports SSE3, e.g. by running `cat /proc/cpuinfo | grep SSE3`. Unless it comes back with `SSE3` your CPU doesn't support SSE3.
 
 To install [opemu-linux](https://github.com/mirh/opemu-linux) first clone the repository:
 ```bash


### PR DESCRIPTION
### What
Added a small paragraph on how to fix missing SSE3 Support by installing the opemu-linux kernel module.
### Why
I just want to save others from going through these two issues: https://github.com/darlinghq/darling/issues/776, https://github.com/darlinghq/darling/issues/882, before arriving at https://github.com/darlinghq/darling/issues/1497 and figuring out the solution by @Mabbs works for them too.
### Why like this
Yes build instructions might not be the perfectly correct page for this paragraph, but I didn't find any other “Known Issues Section” and the ZFS problem is also handled here, therefore I think it is not too out of place
### Open questions/concerns
Only question, should I add a warning about installing some random kernel module from GitHub ?