### PR TITLE
Update build-instructions.md to add instructions for RHEL 10

### DIFF
--- a/src/build-instructions.md
+++ b/src/build-instructions.md
@@ -86,7 +86,7 @@ libXcursor-devel libXrandr-devel giflib-devel pulseaudio-libs-devel libxkbfile-d
 llvm libcap-devel libbsd-devel libfuse-devel ffmpeg-devel
 ```
 
-Please note that the 32-bit libraries are no longer available in RHEL 10, and as such you must disable the 32-bit libraries on that platform. The procedure to do that is documented in the relevant section below.
+Please note that the 32-bit libraries are no longer available in RHEL 10, and as such you must disable the 32-bit libraries on that platform. See [Disabling 32-bit Libraries](#disabling-32-bit-libraries) for more details.
 
 **Fedora 43, RHEL 9, CentOS Stream 9, and AlmaLinux 9**
 


### PR DESCRIPTION
Add instructions for RHEL 10, and also note that you have to disable 32-bit libraries in order to get it to compile, as these are no longer available in RHEL 10.