### PR TITLE
Fix Vulkan package name in build instructions

### DIFF
--- a/src/build-instructions.md
+++ b/src/build-instructions.md
@@ -38,7 +38,7 @@ sudo apt install cmake clang bison flex xz-utils libfuse-dev libudev-dev pkg-con
 libc6-dev-i386 libcap2-bin git git-lfs libglu1-mesa-dev libcairo2-dev \
 libgl1-mesa-dev libtiff5-dev libfreetype6-dev libxml2-dev libegl1-mesa-dev libfontconfig1-dev \
 libbsd-dev libxrandr-dev libxcursor-dev libgif-dev libpulse-dev libavformat-dev libavcodec-dev \
-libswresample-dev libdbus-1-dev libxkbfile-dev libssl-dev llvm-dev livvulkan-dev \
+libswresample-dev libdbus-1-dev libxkbfile-dev libssl-dev llvm-dev libvulkan-dev \
 libcurl4-openssl-dev libedit-dev
 ```
 
@@ -49,7 +49,7 @@ sudo apt install cmake clang bison flex xz-utils libfuse-dev libudev-dev pkg-con
 libc6-dev-i386 libcap2-bin git git-lfs libglu1-mesa-dev libcairo2-dev \
 libgl1-mesa-dev libtiff5-dev libfreetype6-dev libxml2-dev libegl1-mesa-dev libfontconfig1-dev \
 libbsd-dev libxrandr-dev libxcursor-dev libgif-dev libpulse-dev libavformat-dev libavcodec-dev \
-libswresample-dev libdbus-1-dev libxkbfile-dev libssl-dev llvm-dev livvulkan-dev \
+libswresample-dev libdbus-1-dev libxkbfile-dev libssl-dev llvm-dev libvulkan-dev \
 libcurl4-openssl-dev libedit-dev
 ```
 


### PR DESCRIPTION
Updated Vulkan development package from 'livvulkan-dev' to 'libvulkan-dev' in build instructions.