### PR TITLE
fix: correct 5 typos in documentation

### DIFF
--- a/src/build-instructions.md
+++ b/src/build-instructions.md
@@ -264,9 +264,9 @@ If you wish to properly move your Darling installation, the only supported optio
 
 ### Manually Setting CMAKE_C_COMPILER and CMAKE_CXX_COMPILER.
 
-If `CMAKE_C_COMPILER` and `CMAKE_CXX_COMPILER` are not already set, the configuation script will try to locate `clang`/`clang++`.
+If `CMAKE_C_COMPILER` and `CMAKE_CXX_COMPILER` are not already set, the configuration script will try to locate `clang`/`clang++`.
 
-Normally, you don't need to worry about setting these variables. With that being said, you can add `-DCMAKE_C_COMPILER="/absolute/path/to/clang"` and `-DCMAKE_CXX_COMPILER="/absolute/path/to/clang++"` when configuring the build to force the configuation script to use a specific clang compiler.
+Normally, you don't need to worry about setting these variables. With that being said, you can add `-DCMAKE_C_COMPILER="/absolute/path/to/clang"` and `-DCMAKE_CXX_COMPILER="/absolute/path/to/clang++"` when configuring the build to force the configuration script to use a specific clang compiler.
 
 ### Building Only Certain Components
 

--- a/src/contributing/generating-syscalls.md
+++ b/src/contributing/generating-syscalls.md
@@ -2,7 +2,7 @@
 
 While not common, there are situations where you might need to regenerate syscalls. Fortunately, Apple provides a convenient perl script called `create-syscalls.pl`. The script is located in `[XNU]/libsyscall/xcodescripts/`.
 
-## Understanding `create-syscalls.pl`'s Arugments
+## Understanding `create-syscalls.pl`'s Arguments
 
 When you try to run the command, without any arguments, you will get the following prompt:
 

--- a/src/internals/darlingserver/duct-tape.md
+++ b/src/internals/darlingserver/duct-tape.md
@@ -11,7 +11,7 @@ essentially duct-tapes the XNU code into something we can use.
 Because duct-taped code uses XNU kernel headers, including any Linux headers
 would quickly cause header conflicts and complications. Therefore, whenever
 our duct-taping code needs to use some Linux functionality, we do one of two
-things: either manually add declaractions/prototypes (e.g. for simple things
+things: either manually add declarations/prototypes (e.g. for simple things
 like `mmap`) or, more commonly, add hooks for duct-taped code to call into C++
 code. Additionally, duct-taped code is C code, so if it needs to use some
 functionality that the C++ code implements, it *must* use hooks.

--- a/src/internals/darlingserver/interrupts.md
+++ b/src/internals/darlingserver/interrupts.md
@@ -53,7 +53,7 @@ receive a reply, but for the wrong call (the one that was just interrupted).
 That's why another job of `interrupt_enter` on the client side is to handle
 unexpected replies and push them back to the server.
 
-It allocates a buffer (on the stack) large enough to accomodate all possible
+It allocates a buffer (on the stack) large enough to accommodate all possible
 replies and file descriptors. When it receives a reply it did not expect (i.e.
 a reply that is not for the `interrupt_enter` call), it sends it back to the
 server using a special `push_reply` message, which the server uses to save the

--- a/src/internals/darlingserver/kqchannels.md
+++ b/src/internals/darlingserver/kqchannels.md
@@ -27,7 +27,7 @@ XNU code for event details.
 
 ## Process Filters
 
-Process filters hook into the target Process instance in dalringserver to have
+Process filters hook into the target Process instance in darlingserver to have
 it notify us when certain events like forks, execs, and deaths occur.
 
 A special case occurs when a process forks because there is an old, deprecated


### PR DESCRIPTION
## Summary
Correct 5 typos across 5 files in the documentation:

| File | Fix |
|------|-----|
| `src/contributing/generating-syscalls.md` | Arugments → Arguments |
| `src/internals/darlingserver/interrupts.md` | accomodate → accommodate |
| `src/build-instructions.md` | configuation → configuration (2 places) |
| `src/internals/darlingserver/kqchannels.md` | dalringserver → darlingserver |
| `src/internals/darlingserver/duct-tape.md` | declaractions → declarations |

Fixes #94